### PR TITLE
Bump `prompt-tsx` to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 				"@azure/core-auth": "^1.8.0",
 				"@azure/core-sse": "^2.1.3",
 				"@microsoft/tiktokenizer": "^1.0.8",
-				"@vscode/prompt-tsx": "^0.3.0-alpha.12",
+				"@vscode/prompt-tsx": "^0.3.0-alpha.19",
 				"@vscode/prompt-tsx-elements": "^0.1.0",
 				"cheerio": "^1.0.0-rc.12",
 				"jsdom": "^25.0.1"
@@ -820,9 +820,10 @@
 			"dev": true
 		},
 		"node_modules/@vscode/prompt-tsx": {
-			"version": "0.3.0-alpha.12",
-			"resolved": "https://registry.npmjs.org/@vscode/prompt-tsx/-/prompt-tsx-0.3.0-alpha.12.tgz",
-			"integrity": "sha512-2ANm569UBXIzjPbaDFjzRkucelhsnlnmYIPdDo+USeFq2Do0Q70gKiiRWYrQf5rPqCxrChDvgU14nsdJLUSaOQ=="
+			"version": "0.3.0-alpha.19",
+			"resolved": "https://registry.npmjs.org/@vscode/prompt-tsx/-/prompt-tsx-0.3.0-alpha.19.tgz",
+			"integrity": "sha512-6uZWV5aoh1aYPFd7bNzMzUTknk4Pm7wdRFrJAm2VJGXJJ2wBaY9O7lMSXDsP1dYCSkhen6jBpAG+1QxG7nwomw==",
+			"license": "MIT"
 		},
 		"node_modules/@vscode/prompt-tsx-elements": {
 			"version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
 		"@azure/core-auth": "^1.8.0",
 		"@azure/core-sse": "^2.1.3",
 		"@microsoft/tiktokenizer": "^1.0.8",
-		"@vscode/prompt-tsx": "^0.3.0-alpha.12",
+		"@vscode/prompt-tsx": "^0.3.0-alpha.19",
 		"@vscode/prompt-tsx-elements": "^0.1.0",
 		"cheerio": "^1.0.0-rc.12",
 		"jsdom": "^25.0.1"

--- a/src/promptTracing.ts
+++ b/src/promptTracing.ts
@@ -16,7 +16,7 @@ export function toggleTracing(extensionMode: ExtensionMode) {
 }
 
 export async function renderPrompt<P extends BasePromptElementProps>(endpoint: IChatEndpointInfo, ctor: PromptElementCtor<P, any>, props: P, model: LanguageModelChat, token: CancellationToken) {
-    const renderer = new PromptRenderer(endpoint, ctor, props, new AnyTokenizer(model.countTokens));
+    const renderer = new PromptRenderer(endpoint, ctor, props, new AnyTokenizer(model.countTokens, 'vscode'));
     let result: RenderPromptResult;
     if (tracingEnabled) {
         const tracer = new HTMLTracer();


### PR DESCRIPTION
Claude is broken before and after this change, but ruling this out.